### PR TITLE
Add missing license type in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
         "module",
         "zf"
     ],
+    "license": "BSD-3-Clause",
     "homepage": "https://github.com/kokspflanze/ZfcTwig/",
     "authors": [
         {


### PR DESCRIPTION
We read this field within an application to provide a summary of 3rd party licensing and it is missing form this module.
